### PR TITLE
Adding 0.11.0 release blog post

### DIFF
--- a/daprblog/content/posts/2020/2020-10-01-0.11.0-release.md
+++ b/daprblog/content/posts/2020/2020-10-01-0.11.0-release.md
@@ -36,7 +36,7 @@ In similar vain, to ensure multiple layers of access control to increase overall
 ### Bindings
 
 - [RethinkDB binding](https://github.com/dapr/components-contrib/tree/master/state)
-- [Bi-directional PostgreSQL]((https://github.com/dapr/components-contrib/tree/master/state)
+- [Bi-directional PostgreSQL binding](https://github.com/dapr/components-contrib/tree/master/state)
 
 ### Middleware
 


### PR DESCRIPTION
PR for a 0.11.0 release post to be published 09/29/2020.

Please review and add feedback but **do not merge** after approval until release date (merge to master triggers a publication).

A staging preview link will be created automatically during this review process.