### PR TITLE
Removing redundant period in blog title

### DIFF
--- a/daprblog/content/posts/2020/2020-10-20-path-to-production-release.md
+++ b/daprblog/content/posts/2020/2020-10-20-path-to-production-release.md
@@ -1,7 +1,7 @@
 ---
 date: "2020-10-20T09:00:00-07:00"
-title: "The path to v.1.0, production ready Dapr"
-linkTitle: "The path to v.1.0, production ready Dapr"
+title: "The path to v1.0, production ready Dapr"
+linkTitle: "The path to v1.0, production ready Dapr"
 author: Dapr Maintainers
 type: blog
 ---


### PR DESCRIPTION
Just noticed the blog title includes "v.1.0", should be "v1.0"...