### PR TITLE
Use Google Analytics 4 ID

### DIFF
--- a/daprblog/config.toml
+++ b/daprblog/config.toml
@@ -8,8 +8,9 @@ theme = "docsy"
 [permalinks]
 posts = "/:section/:year/:month/:day/:slug/"
 
-[services.googleAnalytics]
-id = "G-60C6Q1ETC1"
+# Disable until https://github.com/dapr/blog/issues/94 is fixed
+# [services.googleAnalytics]
+# id = "G-60C6Q1ETC1"
 
 # Allow embedded HTML in pages
 [markup]

--- a/daprblog/config.toml
+++ b/daprblog/config.toml
@@ -8,9 +8,8 @@ theme = "docsy"
 [permalinks]
 posts = "/:section/:year/:month/:day/:slug/"
 
-# Google Analytics - Dapr Blog Property
 [services.googleAnalytics]
-id = "UA-149338238-2"
+id = "G-60C6Q1ETC1"
 
 # Allow embedded HTML in pages
 [markup]

--- a/daprblog/layouts/partials/hooks/head-end.html
+++ b/daprblog/layouts/partials/hooks/head-end.html
@@ -1,0 +1,11 @@
+{{ if hugo.IsProduction -}}
+{{/* Google tag (gtag.js) */ -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-60C6Q1ETC1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-60C6Q1ETC1');
+</script>
+{{ end -}}


### PR DESCRIPTION
- Contributes to #92

**IMPORTANT**:
> 
> Since the GA4 ID is _the_ ID for all Dapr things web, this means that **all web events**, including page_views etc. **from the _main_ website and the _docs_ subdomain, will be sent to the blog UA ID** once this PR is merged and the UA ID is [connect]ed from the GA4 ID.
>
> Please **confirm that this is ok with you** @msfussell @greenie-msft 

/cc @nate-double-u

[connect]: https://support.google.com/analytics/answer/9973999
