### PR TITLE
fix: allow workflow_dispatch for blog SWA deployment

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-ocean-0d6f6e61e.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-ocean-0d6f6e61e.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
## Problem
The build job condition excludes `workflow_dispatch`:
``
if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
``

## Fix
``
if: github.event.action != 'closed'
``
This works for all event types. When merged, the push event will deploy to the new SWA.